### PR TITLE
Feat/16

### DIFF
--- a/src/main/java/com/example/trx/apis/judge/JudgeController.java
+++ b/src/main/java/com/example/trx/apis/judge/JudgeController.java
@@ -1,0 +1,34 @@
+package com.example.trx.apis.judge;
+
+import com.example.trx.apis.dto.ApiResult;
+import com.example.trx.apis.judge.dto.JudgeCreateRequest;
+import com.example.trx.apis.judge.dto.JudgeResponse;
+import com.example.trx.service.judge.JudgeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/judges")
+@RequiredArgsConstructor
+@Tag(name = "Judges", description = "심사위원 관리 API")
+public class JudgeController {
+
+    private final JudgeService judgeService;
+
+    @Operation(summary = "심사위원 등록", description = "관리자가 심사위원 계정을 생성합니다.")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResult<JudgeResponse> createJudge(@Valid @RequestBody JudgeCreateRequest request) {
+        return ApiResult.succeed(judgeService.createJudge(request));
+    }
+}

--- a/src/main/java/com/example/trx/apis/judge/JudgeController.java
+++ b/src/main/java/com/example/trx/apis/judge/JudgeController.java
@@ -11,7 +11,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import java.util.List;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -34,6 +36,13 @@ public class JudgeController {
     @PreAuthorize("hasRole('ADMIN')")
     public ApiResult<JudgeResponse> createJudge(@Valid @RequestBody JudgeCreateRequest request) {
         return ApiResult.succeed(judgeService.createJudge(request));
+    }
+
+    @Operation(summary = "심사위원 목록 조회", description = "심사위원의 기본 정보를 조회합니다.")
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResult<List<JudgeResponse>> getJudges() {
+        return ApiResult.succeed(judgeService.getJudges());
     }
 
     @Operation(summary = "심사위원 정보 수정", description = "관리자가 심사위원 정보를 수정합니다.")

--- a/src/main/java/com/example/trx/apis/judge/JudgeController.java
+++ b/src/main/java/com/example/trx/apis/judge/JudgeController.java
@@ -3,6 +3,7 @@ package com.example.trx.apis.judge;
 import com.example.trx.apis.dto.ApiResult;
 import com.example.trx.apis.judge.dto.JudgeCreateRequest;
 import com.example.trx.apis.judge.dto.JudgeResponse;
+import com.example.trx.apis.judge.dto.JudgeUpdateRequest;
 import com.example.trx.service.judge.JudgeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,7 +11,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -30,5 +33,15 @@ public class JudgeController {
     @PreAuthorize("hasRole('ADMIN')")
     public ApiResult<JudgeResponse> createJudge(@Valid @RequestBody JudgeCreateRequest request) {
         return ApiResult.succeed(judgeService.createJudge(request));
+    }
+
+    @Operation(summary = "심사위원 정보 수정", description = "관리자가 심사위원 정보를 수정합니다.")
+    @PutMapping("/{judgeId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResult<JudgeResponse> updateJudge(
+        @PathVariable Long judgeId,
+        @Valid @RequestBody JudgeUpdateRequest request
+    ) {
+        return ApiResult.succeed(judgeService.updateJudge(judgeId, request));
     }
 }

--- a/src/main/java/com/example/trx/apis/judge/JudgeController.java
+++ b/src/main/java/com/example/trx/apis/judge/JudgeController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -43,5 +44,14 @@ public class JudgeController {
         @Valid @RequestBody JudgeUpdateRequest request
     ) {
         return ApiResult.succeed(judgeService.updateJudge(judgeId, request));
+    }
+
+    @Operation(summary = "심사위원 비활성화", description = "심사위원을 사용 불가 상태로 전환합니다.")
+    @DeleteMapping("/{judgeId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResult<Void> deactivateJudge(@PathVariable Long judgeId) {
+        judgeService.deactivateJudge(judgeId);
+        return ApiResult.succeed(null);
     }
 }

--- a/src/main/java/com/example/trx/apis/judge/dto/JudgeCreateRequest.java
+++ b/src/main/java/com/example/trx/apis/judge/dto/JudgeCreateRequest.java
@@ -1,0 +1,33 @@
+package com.example.trx.apis.judge.dto;
+
+import com.example.trx.domain.event.DisciplineCode;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JudgeCreateRequest {
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String password;
+
+    @NotNull
+    private DisciplineCode disciplineCode;
+
+    @NotNull
+    private Integer judgeNumber;
+}

--- a/src/main/java/com/example/trx/apis/judge/dto/JudgeResponse.java
+++ b/src/main/java/com/example/trx/apis/judge/dto/JudgeResponse.java
@@ -1,0 +1,19 @@
+package com.example.trx.apis.judge.dto;
+
+import com.example.trx.domain.event.DisciplineCode;
+import com.example.trx.domain.judge.JudgeStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class JudgeResponse {
+    private final Long id;
+    private final String name;
+    private final String username;
+    private final Integer judgeNumber;
+    private final DisciplineCode disciplineCode;
+    private final JudgeStatus status;
+}

--- a/src/main/java/com/example/trx/apis/judge/dto/JudgeUpdateRequest.java
+++ b/src/main/java/com/example/trx/apis/judge/dto/JudgeUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.example.trx.apis.judge.dto;
+
+import com.example.trx.domain.event.DisciplineCode;
+import com.example.trx.domain.judge.JudgeStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JudgeUpdateRequest {
+
+    @NotBlank
+    private String name;
+
+    @NotNull
+    private DisciplineCode disciplineCode;
+
+    @NotNull
+    private JudgeStatus status;
+}

--- a/src/main/java/com/example/trx/config/SecurityConfig.java
+++ b/src/main/java/com/example/trx/config/SecurityConfig.java
@@ -1,21 +1,45 @@
 package com.example.trx.config;
 
+import com.example.trx.support.security.JwtAuthenticationEntryPoint;
+import com.example.trx.support.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
+        JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
             .csrf(csrf -> csrf.disable())
-            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
-            .httpBasic(httpBasic -> {});
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(HttpMethod.POST, "/api/v1/admins", "/api/v1/admins/login").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/notices/**", "/api", "/api/swagger-ui.html",
+                    "/api/swagger-ui/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .anyRequest().authenticated())
+            .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 

--- a/src/main/java/com/example/trx/domain/judge/Judge.java
+++ b/src/main/java/com/example/trx/domain/judge/Judge.java
@@ -35,6 +35,11 @@ public class Judge extends BaseTimeEntity {
     @Column(name = "name", nullable = false, length = 64)
     private String name;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    @Builder.Default
+    private JudgeStatus status = JudgeStatus.ACTIVE;
+
     // 관계: Judge 1 : N ScoreTotal
     @OneToMany(mappedBy = "judge", cascade = CascadeType.ALL, orphanRemoval = false)
     @Builder.Default

--- a/src/main/java/com/example/trx/domain/judge/Judge.java
+++ b/src/main/java/com/example/trx/domain/judge/Judge.java
@@ -1,6 +1,7 @@
 package com.example.trx.domain.judge;
 
 import com.example.trx.domain.event.ContestEvent;
+import com.example.trx.domain.event.DisciplineCode;
 import com.example.trx.domain.run.Run;
 import com.example.trx.domain.score.ScoreTotal;
 import com.example.trx.support.util.BaseTimeEntity;
@@ -26,7 +27,7 @@ public class Judge extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "contest_event_id", nullable = false)
+    @JoinColumn(name = "contest_event_id")
     private ContestEvent contestEvent;
 
     @Column(name = "judge_number", nullable = false)
@@ -34,6 +35,16 @@ public class Judge extends BaseTimeEntity {
 
     @Column(name = "name", nullable = false, length = 64)
     private String name;
+
+    @Column(name = "username", nullable = false, unique = true, length = 50)
+    private String username;
+
+    @Column(name = "password", nullable = false, length = 255)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "discipline_code", nullable = false, length = 32)
+    private DisciplineCode disciplineCode;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 16)

--- a/src/main/java/com/example/trx/domain/judge/JudgeStatus.java
+++ b/src/main/java/com/example/trx/domain/judge/JudgeStatus.java
@@ -1,0 +1,6 @@
+package com.example.trx.domain.judge;
+
+public enum JudgeStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/com/example/trx/domain/judge/exception/JudgeAlreadyExistsException.java
+++ b/src/main/java/com/example/trx/domain/judge/exception/JudgeAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package com.example.trx.domain.judge.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class JudgeAlreadyExistsException extends RuntimeException {
+    public JudgeAlreadyExistsException(String username) {
+        super("이미 존재하는 심사위원 아이디입니다. username=" + username);
+    }
+}

--- a/src/main/java/com/example/trx/domain/judge/exception/JudgeNotFoundException.java
+++ b/src/main/java/com/example/trx/domain/judge/exception/JudgeNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.trx.domain.judge.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class JudgeNotFoundException extends RuntimeException {
+    public JudgeNotFoundException(Long id) {
+        super("심사위원을 찾을 수 없습니다. id=" + id);
+    }
+}

--- a/src/main/java/com/example/trx/repository/judge/JudgeRepository.java
+++ b/src/main/java/com/example/trx/repository/judge/JudgeRepository.java
@@ -1,0 +1,10 @@
+package com.example.trx.repository.judge;
+
+import com.example.trx.domain.judge.Judge;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JudgeRepository extends JpaRepository<Judge, Long> {
+    boolean existsByUsername(String username);
+    Optional<Judge> findByUsername(String username);
+}

--- a/src/main/java/com/example/trx/repository/judge/JudgeRepository.java
+++ b/src/main/java/com/example/trx/repository/judge/JudgeRepository.java
@@ -1,6 +1,7 @@
 package com.example.trx.repository.judge;
 
 import com.example.trx.domain.judge.Judge;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,5 @@ public interface JudgeRepository extends JpaRepository<Judge, Long> {
     boolean existsByUsername(String username);
     Optional<Judge> findByUsername(String username);
     Optional<Judge> findByIdAndDeletedFalse(Long id);
+    List<Judge> findAllByDeletedFalse();
 }

--- a/src/main/java/com/example/trx/repository/judge/JudgeRepository.java
+++ b/src/main/java/com/example/trx/repository/judge/JudgeRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface JudgeRepository extends JpaRepository<Judge, Long> {
     boolean existsByUsername(String username);
     Optional<Judge> findByUsername(String username);
+    Optional<Judge> findByIdAndDeletedFalse(Long id);
 }

--- a/src/main/java/com/example/trx/repository/notice/NoticeRepository.java
+++ b/src/main/java/com/example/trx/repository/notice/NoticeRepository.java
@@ -3,13 +3,16 @@ package com.example.trx.repository.notice;
 import com.example.trx.domain.notice.Notice;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
-    List<Notice> findByPinnedIsTrueAndApplyAtLessThanEqual(LocalDateTime applyAt, Sort sort);
+    List<Notice> findByPinnedIsTrueAndApplyAtLessThanEqualAndDeletedFalse(LocalDateTime applyAt, Sort sort);
 
-    Page<Notice> findByPinnedIsFalseAndApplyAtLessThanEqual(LocalDateTime applyAt, Pageable pageable);
+    Page<Notice> findByPinnedIsFalseAndApplyAtLessThanEqualAndDeletedFalse(LocalDateTime applyAt, Pageable pageable);
+
+    Optional<Notice> findByIdAndDeletedFalse(Long id);
 }

--- a/src/main/java/com/example/trx/service/judge/JudgeService.java
+++ b/src/main/java/com/example/trx/service/judge/JudgeService.java
@@ -2,11 +2,12 @@ package com.example.trx.service.judge;
 
 import com.example.trx.apis.judge.dto.JudgeCreateRequest;
 import com.example.trx.apis.judge.dto.JudgeResponse;
+import com.example.trx.apis.judge.dto.JudgeUpdateRequest;
 import com.example.trx.domain.judge.Judge;
 import com.example.trx.domain.judge.JudgeStatus;
 import com.example.trx.domain.judge.exception.JudgeAlreadyExistsException;
+import com.example.trx.domain.judge.exception.JudgeNotFoundException;
 import com.example.trx.repository.judge.JudgeRepository;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -43,6 +44,25 @@ public class JudgeService {
             .judgeNumber(saved.getJudgeNumber())
             .disciplineCode(saved.getDisciplineCode())
             .status(saved.getStatus())
+            .build();
+    }
+
+    @Transactional
+    public JudgeResponse updateJudge(Long judgeId, JudgeUpdateRequest request) {
+        Judge judge = judgeRepository.findById(judgeId)
+            .orElseThrow(() -> new JudgeNotFoundException(judgeId));
+
+        judge.setName(request.getName());
+        judge.setDisciplineCode(request.getDisciplineCode());
+        judge.setStatus(request.getStatus());
+
+        return JudgeResponse.builder()
+            .id(judge.getId())
+            .name(judge.getName())
+            .username(judge.getUsername())
+            .judgeNumber(judge.getJudgeNumber())
+            .disciplineCode(judge.getDisciplineCode())
+            .status(judge.getStatus())
             .build();
     }
 }

--- a/src/main/java/com/example/trx/service/judge/JudgeService.java
+++ b/src/main/java/com/example/trx/service/judge/JudgeService.java
@@ -49,7 +49,7 @@ public class JudgeService {
 
     @Transactional
     public JudgeResponse updateJudge(Long judgeId, JudgeUpdateRequest request) {
-        Judge judge = judgeRepository.findById(judgeId)
+        Judge judge = judgeRepository.findByIdAndDeletedFalse(judgeId)
             .orElseThrow(() -> new JudgeNotFoundException(judgeId));
 
         judge.setName(request.getName());
@@ -68,8 +68,9 @@ public class JudgeService {
 
     @Transactional
     public void deactivateJudge(Long judgeId) {
-        Judge judge = judgeRepository.findById(judgeId)
+        Judge judge = judgeRepository.findByIdAndDeletedFalse(judgeId)
             .orElseThrow(() -> new JudgeNotFoundException(judgeId));
         judge.setStatus(JudgeStatus.INACTIVE);
+        judge.markDeleted();
     }
 }

--- a/src/main/java/com/example/trx/service/judge/JudgeService.java
+++ b/src/main/java/com/example/trx/service/judge/JudgeService.java
@@ -65,4 +65,11 @@ public class JudgeService {
             .status(judge.getStatus())
             .build();
     }
+
+    @Transactional
+    public void deactivateJudge(Long judgeId) {
+        Judge judge = judgeRepository.findById(judgeId)
+            .orElseThrow(() -> new JudgeNotFoundException(judgeId));
+        judge.setStatus(JudgeStatus.INACTIVE);
+    }
 }

--- a/src/main/java/com/example/trx/service/judge/JudgeService.java
+++ b/src/main/java/com/example/trx/service/judge/JudgeService.java
@@ -1,0 +1,48 @@
+package com.example.trx.service.judge;
+
+import com.example.trx.apis.judge.dto.JudgeCreateRequest;
+import com.example.trx.apis.judge.dto.JudgeResponse;
+import com.example.trx.domain.judge.Judge;
+import com.example.trx.domain.judge.JudgeStatus;
+import com.example.trx.domain.judge.exception.JudgeAlreadyExistsException;
+import com.example.trx.repository.judge.JudgeRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class JudgeService {
+
+    private final JudgeRepository judgeRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public JudgeResponse createJudge(JudgeCreateRequest request) {
+        if (judgeRepository.existsByUsername(request.getUsername())) {
+            throw new JudgeAlreadyExistsException(request.getUsername());
+        }
+
+        Judge judge = Judge.builder()
+            .name(request.getName())
+            .username(request.getUsername())
+            .password(passwordEncoder.encode(request.getPassword()))
+            .disciplineCode(request.getDisciplineCode())
+            .judgeNumber(request.getJudgeNumber())
+            .status(JudgeStatus.ACTIVE)
+            .build();
+
+        Judge saved = judgeRepository.save(judge);
+
+        return JudgeResponse.builder()
+            .id(saved.getId())
+            .name(saved.getName())
+            .username(saved.getUsername())
+            .judgeNumber(saved.getJudgeNumber())
+            .disciplineCode(saved.getDisciplineCode())
+            .status(saved.getStatus())
+            .build();
+    }
+}

--- a/src/main/java/com/example/trx/service/judge/JudgeService.java
+++ b/src/main/java/com/example/trx/service/judge/JudgeService.java
@@ -8,6 +8,8 @@ import com.example.trx.domain.judge.JudgeStatus;
 import com.example.trx.domain.judge.exception.JudgeAlreadyExistsException;
 import com.example.trx.domain.judge.exception.JudgeNotFoundException;
 import com.example.trx.repository.judge.JudgeRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -45,6 +47,20 @@ public class JudgeService {
             .disciplineCode(saved.getDisciplineCode())
             .status(saved.getStatus())
             .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<JudgeResponse> getJudges() {
+        return judgeRepository.findAllByDeletedFalse().stream()
+            .map(judge -> JudgeResponse.builder()
+                .id(judge.getId())
+                .name(judge.getName())
+                .username(judge.getUsername())
+                .judgeNumber(judge.getJudgeNumber())
+                .disciplineCode(judge.getDisciplineCode())
+                .status(judge.getStatus())
+                .build())
+            .collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/main/java/com/example/trx/support/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/trx/support/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package com.example.trx.support.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write("{\"message\":\"Unauthorized\"}");
+    }
+}

--- a/src/main/java/com/example/trx/support/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/trx/support/security/JwtAuthenticationFilter.java
@@ -1,0 +1,42 @@
+package com.example.trx.support.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/trx/support/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/trx/support/security/JwtTokenProvider.java
@@ -1,15 +1,27 @@
 package com.example.trx.support.security;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -42,6 +54,49 @@ public class JwtTokenProvider {
             .setExpiration(Date.from(expiresAt))
             .signWith(signingKey, SignatureAlgorithm.HS256)
             .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+        List<String> roles = getRoles(claims);
+        return new UsernamePasswordAuthenticationToken(
+            claims.getSubject(),
+            token,
+            roles.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList())
+        );
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException | SignatureException ex) {
+            return false;
+        } catch (ExpiredJwtException ex) {
+            return false;
+        } catch (UnsupportedJwtException | IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    private Claims parseClaims(String token) {
+        Jws<Claims> claimsJws = Jwts.parserBuilder()
+            .setSigningKey(signingKey)
+            .build()
+            .parseClaimsJws(token);
+        return claimsJws.getBody();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> getRoles(Claims claims) {
+        Object roles = claims.get("roles");
+        if (roles instanceof List<?>) {
+            return ((List<?>) roles).stream()
+                .filter(Objects::nonNull)
+                .map(Object::toString)
+                .collect(Collectors.toList());
+        }
+        return Collections.emptyList();
     }
 
     private byte[] resolveKeyBytes(String secret) {

--- a/src/main/java/com/example/trx/support/util/BaseTimeEntity.java
+++ b/src/main/java/com/example/trx/support/util/BaseTimeEntity.java
@@ -21,4 +21,15 @@ public abstract class BaseTimeEntity {
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    @Column(name = "deleted", nullable = false)
+    private boolean deleted = false;
+
+    public void markDeleted() {
+        this.deleted = true;
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #16 

## ✨ 변경 내용
- 공통 BaseTimeEntity에 deleted 플래그와 markDeleted() 추가, 공지·심사위원 삭제 로직을 소프
  트 삭제로 전환하고 조회 쿼리에도 deleted=false 조건 적용.
- 관리자 계정 도메인·JWT 기반 인증 인프라 구축, /api/v1/admins에서 관리자 생성·로그인(토큰
  발급) 가능하도록 구현.
- JWT 필터, 엔트리포인트, 시큐리티 설정을 도입해 관리자 전용 API 보호(공지 공개, 관리자/심
  사위원 관리엔 인증·권한 검사 적용).
- 심사위원 엔티티 확장(계정 정보, 종목, 상태) 및 심사위원 생성·수정·비활성화 API 구현, 관리
  자 권한에서만 실행되도록 설정.
- 심사위원 전체 조회 API 추가(이름/아이디/종목/상태 반환) 및 중복 아이디·미존재 예외 응답
  처리.
- 공지 API 목록·상세·수정·삭제 로직을 소프트 삭제와 일관되게 동작하도록 리팩터링하고 환경
  변수 기반 설정(.env) 정비.

## ✅ 체크리스트
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 관련 문서/주석 보강
