### PR TITLE
fix: CORS 설정 개선

### DIFF
--- a/src/main/java/com/example/trx/config/SecurityConfig.java
+++ b/src/main/java/com/example/trx/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.trx.config;
 
 import com.example.trx.support.security.JwtAuthenticationEntryPoint;
 import com.example.trx.support.security.JwtAuthenticationFilter;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -15,6 +16,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -33,7 +37,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-            .cors(Customizer.withDefaults())
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .csrf(csrf -> csrf.disable())
             .httpBasic(AbstractHttpConfigurer::disable)
             .formLogin(formLogin -> formLogin.disable())
@@ -70,5 +74,20 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("Authorization", "Content-Type"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #46 

## ✨ 변경 내용
- SecurityFilterChain이 명시적인 CORS 정책을 사용하도록 구성했습니다.
- CorsConfigurationSource 빈을 도입해 PUT/DELETE 등 모든 메서드에 대해 프리플라이트가 허용
  되도록 허용 메서드·헤더·Origin 패턴을 지정했습니다.
- 이로 인해 관리자 대시보드 등에서 PUT /api/v1/notices/{id} 같은 요청이 더 이상 401로 차단
  되지 않습니다.

## ✅ 체크리스트
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 관련 문서/주석 보강
