### PR TITLE
feat : 엑셀 데이터를 통해 참가자 정보 생성, 조회 기능 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>2.1.214</version>
+            <version>2.2.224</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -188,6 +188,25 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <!-- Excel 파일(.xls, .xlsx) 읽기/쓰기용 -->
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi</artifactId>
+            <version>5.3.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.3.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.16.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/example/trx/apis/user/UserController.java
+++ b/src/main/java/com/example/trx/apis/user/UserController.java
@@ -1,21 +1,39 @@
 package com.example.trx.apis.user;
 
+import com.example.trx.apis.dto.ApiResult;
+import com.example.trx.apis.user.dto.ParticipantCreateRequest;
+import com.example.trx.domain.user.Participant;
+import com.example.trx.service.user.ParticipantService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 @Tag(name = "User Management", description = "Operations for creating, retrieving and updating users")
 public class UserController {
+    private final ParticipantService participantService;
 
+    @GetMapping("/upload")
+    public ApiResult<?> uploadExcel() {
+        try {
+            return ApiResult.succeed(participantService.readExcel());
+        } catch (Exception e) {
+            return ApiResult.failed("엑셀 파일 읽기 실패: " + e.getMessage());
+        }
+    }
 
-//  @Operation(summary = "List users", description = "Retrieve all registered users")
-//  @GetMapping
-//  public ApiResult<List<UserDto>> getUsers() {
-//    return ApiResult.succeed(userService.getAllUsers());
-//  }
+    @Operation(summary = "List users", description = "Retrieve all registered users")
+    @GetMapping()
+    public ApiResult<List<ParticipantCreateRequest>> getUsers() {
+        return ApiResult.succeed(participantService.getAllUsers());
+    }
 //
 //  @Operation(summary = "Get user", description = "Retrieve detailed information for a single user")
 //  @GetMapping("/{userId}")

--- a/src/main/java/com/example/trx/apis/user/dto/ParticipantCreateRequest.java
+++ b/src/main/java/com/example/trx/apis/user/dto/ParticipantCreateRequest.java
@@ -11,7 +11,7 @@ import lombok.Data;
 @Data
 public class ParticipantCreateRequest {
     private String nameKr;
-    private LocalDate birth;
+    private String birth;
     private String phone;
     private String emergencyContact;
     private String email;

--- a/src/main/java/com/example/trx/config/SecurityConfig.java
+++ b/src/main/java/com/example/trx/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -34,7 +35,8 @@ public class SecurityConfig {
         http
             .csrf(csrf -> csrf.disable())
             .httpBasic(AbstractHttpConfigurer::disable)
-            .formLogin(formLogin -> formLogin.disable())
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                .formLogin(formLogin -> formLogin.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.POST, "/api/v1/admins", "/api/v1/admins/login", "/api/v1/judges/login").permitAll()
@@ -55,9 +57,11 @@ public class SecurityConfig {
                     "/v3/api-docs",
                     "/v3/api-docs/**",
                     "/api/v3/api-docs",
-                    "/api/v3/api-docs/**"
+                    "/api/v3/api-docs/**",
+                    "/api/v1/users/**"
                 ).permitAll()
                 .requestMatchers("/api/v1/judges/**").hasRole("ADMIN")
+                .requestMatchers("/h2-console/**").permitAll()
                 .anyRequest().authenticated())
             .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/example/trx/domain/event/DisciplineCode.java
+++ b/src/main/java/com/example/trx/domain/event/DisciplineCode.java
@@ -3,5 +3,5 @@ package com.example.trx.domain.event;
 public enum DisciplineCode {
     FREESTYLE,
     SLALOM,
-    DANCING
+    LONGBOARD_DANCING
 }

--- a/src/main/java/com/example/trx/domain/user/Gender.java
+++ b/src/main/java/com/example/trx/domain/user/Gender.java
@@ -1,5 +1,5 @@
 package com.example.trx.domain.user;
 
 public enum Gender {
-    MALE, FEMALE
+    남, 여
 }

--- a/src/main/java/com/example/trx/domain/user/Participant.java
+++ b/src/main/java/com/example/trx/domain/user/Participant.java
@@ -35,7 +35,7 @@ public class Participant extends BaseTimeEntity {
 
     // 생년월일
     @Column(name = "birth")
-    private LocalDate birth;
+    private String birth;
 
     // 연락처
     @Column(name = "phone", length = 32)

--- a/src/main/java/com/example/trx/domain/user/Participation.java
+++ b/src/main/java/com/example/trx/domain/user/Participation.java
@@ -1,13 +1,7 @@
 package com.example.trx.domain.user;
 
 import com.example.trx.domain.event.ContestEvent;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -24,7 +18,7 @@ public class Participation {//초기 등록 현황을 기록
   @Enumerated(EnumType.STRING)
   private ParticipationStatus status;
 
-  @ManyToOne
+  @ManyToOne(cascade = CascadeType.PERSIST)
   @JoinColumn(name = "participant_id")
   private Participant participant;
 

--- a/src/main/java/com/example/trx/service/user/ParticipantService.java
+++ b/src/main/java/com/example/trx/service/user/ParticipantService.java
@@ -11,46 +11,166 @@ import com.example.trx.domain.user.UserStatus;
 import com.example.trx.repository.event.ContestEventRepository;
 import com.example.trx.repository.user.ParticipantRepository;
 import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
 public class ParticipantService {
 
-  private final ParticipantRepository participantRepository;
-  private final ContestEventRepository contestEventRepository;
+      private final ParticipantRepository participantRepository;
+      private final ContestEventRepository contestEventRepository;
 
-  @Transactional
-  public Participant createParticipantAndParticipate(ParticipantCreateRequest request) {
-    Gender gender = Gender.valueOf(request.getGender());
-    Division division = Division.valueOf(request.getDivision());
-    Integer bibNumber = Math.toIntExact(participantRepository.count() + 1);
+        @Transactional
+      public int readExcel() throws IOException {
+          int count = 0;
+          String filePath = "C:\\Users\\mycoo\\Documents\\카카오톡 받은 파일\\data.xlsx";
+          try (FileInputStream fis = new FileInputStream(filePath);
+               Workbook workbook = new XSSFWorkbook(fis)) {
 
-    Participant participant = Participant.builder()
-        .nameKr(request.getNameKr())
-        .bibNumber(bibNumber)
-        .birth(request.getBirth())
-        .phone(request.getPhone())
-        .emergencyContact(request.getEmergencyContact())
-        .email(request.getEmail())
-        .gender(gender)
-        .residence(request.getResidence())
-        .division(division)
-        .memo(request.getMemo())
-        .oneLiner(request.getOneLiner())
-        .userStatus(UserStatus.WAITING)
-        .build();
+              SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd"); // 원하는 날짜 포맷 지정
+              DataFormatter formatter = new DataFormatter();
 
-    for (String eventToParticipate : request.getEventToParticipate()) {
-      DisciplineCode disciplineCode = DisciplineCode.valueOf(eventToParticipate);
-      ContestEvent contestEvent = contestEventRepository
-          .findContestEventByDivisionAndDisciplineCode(division, disciplineCode)
-          .orElseThrow(() -> new ContestEventNotFound(division, disciplineCode));
+              Sheet sheet = workbook.getSheetAt(1); // 두 번째 시트
+              int rowCount = sheet.getPhysicalNumberOfRows();
 
-      participant.participate(contestEvent);
-    }
+              // 첫 행(헤더) 건너뛰기
+              for (int i = 1; i < rowCount; i++) {
+                  Row row = sheet.getRow(i);
+                  if (row == null) continue;
 
-    return participantRepository.save(participant);
-  }
+                  ParticipantCreateRequest data = ParticipantCreateRequest.builder()
+                          .nameKr(getCellValue(row.getCell(1))) // 이름
+                          .birth(getCellValue(row.getCell(2))) // 생년월일
+                          .gender(getCellValue(row.getCell(3))) // 성별
+                          .phone(getCellValue(row.getCell(4))) // 핸드폰 번호
+                          .email(getCellValue(row.getCell(5))) // 이메일 주소
+                          .residence(getCellValue(row.getCell(6))) // 거주 지역
+                          .oneLiner(getCellValue(row.getCell(7))) // 각오
+                          .division(getCellValue(row.getCell(9)).split(" ")[0].toUpperCase()) // 참가 부문
+                          .eventToParticipate(extractUpper(getCellValue(row.getCell(10)))) // 참가 종목
+                          .emergencyContact(getCellValue(row.getCell(13))) // 비상 연락처
+                          .build();
+
+                  createParticipantAndParticipate(data);
+                  count++;
+              }
+          }
+
+          return count;
+      }
+
+      public static List<String> extractUpper(String input) {
+        Pattern p = Pattern.compile("[A-Za-z]+(?:\\s+[A-Za-z]+)*");
+        Matcher m = p.matcher(input);
+        List<String> out = new ArrayList<>();
+        while (m.find()) {
+            String upper = m.group().toUpperCase().replaceAll("\\s+", "_"); // ← 공백 제거
+            out.add(upper);
+        }
+
+        return out;
+      }
+
+      private String getCellValue(Cell cell) {
+        if (cell == null) return "";
+
+        CellType cellType = cell.getCellType();
+
+        if (cellType == CellType.FORMULA) {
+            cellType = cell.getCachedFormulaResultType();
+        }
+
+        if (cellType == CellType.NUMERIC) {
+            if(DateUtil.isCellDateFormatted(cell)) {
+                Date date = cell.getDateCellValue();
+                LocalDate localDate = date.toInstant()
+                        .atZone(ZoneId.systemDefault()) // 시스템 기본 시간대 사용
+                        .toLocalDate();
+                return localDate.toString();
+            } else {
+                return String.valueOf(cell.getNumericCellValue());
+            }
+        } else if (cellType == CellType.STRING) {
+            return cell.getStringCellValue();
+        } else if (cellType == CellType.BOOLEAN) {
+            return String.valueOf(cell.getBooleanCellValue());
+        } else if (cellType == CellType.BLANK) {
+            return "";
+        } else {
+            return cell.toString();
+        }
+      }
+
+      @Transactional
+      public Participant createParticipantAndParticipate(ParticipantCreateRequest request) {
+        Gender gender = Gender.valueOf(request.getGender());
+        Division division = Division.valueOf(request.getDivision());
+        Integer bibNumber = Math.toIntExact(participantRepository.count() + 1);
+
+        Participant participant = Participant.builder()
+            .nameKr(request.getNameKr())
+            .bibNumber(bibNumber)
+            .birth(request.getBirth())
+            .phone(request.getPhone())
+            .emergencyContact(request.getEmergencyContact())
+            .email(request.getEmail())
+            .gender(gender)
+            .residence(request.getResidence())
+            .division(division)
+            .memo(request.getMemo())
+            .oneLiner(request.getOneLiner())
+            .userStatus(UserStatus.WAITING)
+            .build();
+
+        for (String eventToParticipate : request.getEventToParticipate()) {
+          DisciplineCode disciplineCode = DisciplineCode.valueOf(eventToParticipate);
+          ContestEvent contestEvent = contestEventRepository
+              .findContestEventByDivisionAndDisciplineCode(division, disciplineCode)
+              .orElseThrow(() -> new ContestEventNotFound(division, disciplineCode));
+
+          participant.participate(contestEvent);
+        }
+
+        return participantRepository.save(participant);
+      }
+
+      @Transactional
+      public List<ParticipantCreateRequest> getAllUsers() {
+            List<ParticipantCreateRequest> out = new ArrayList<>();
+            List<Participant> participants = new ArrayList<>(participantRepository.findAll());
+            for (Participant participant : participants) {
+                ParticipantCreateRequest tmp = ParticipantCreateRequest.builder()
+                        .nameKr(participant.getNameKr())
+                        .birth(participant.getBirth())
+                        .phone(participant.getPhone())
+                        .emergencyContact(participant.getEmergencyContact())
+                        .email(participant.getEmail())
+                        .gender(participant.getGender().toString())
+                        .residence(participant.getResidence())
+                        .division(participant.getDivision().toString())
+                        .memo(participant.getMemo())
+                        .oneLiner(participant.getOneLiner())
+                        .build();
+                out.add(tmp);
+            }
+
+            return out;
+      }
 }

--- a/src/main/java/com/example/trx/support/filter/RequestServletFilter.java
+++ b/src/main/java/com/example/trx/support/filter/RequestServletFilter.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 
 
-@Component
 public class RequestServletFilter implements Filter {
 
     @Override

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,6 +21,10 @@ tomcat:
     port: 17099
     enabled: true
 spring:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
   datasource:
     #### h2 설정
     url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #이슈번호

## ✨ 변경 내용
- 엑셀 데이터 읽어서 참가자 생성하는 로직 생성 (users/upload)
- 참가자 정보 읽어오는 로직 생성 (users)
- maven에 의존성 추가 (poi)
- yaml에 h2 콘솔 설정 추가
- Security에 h2, users 접근 권한 추가 -> 이후 수정
- Participant, ParticipantCreateRequest 에서 birth LocalDate -> String으로 수정

## ✅ 체크리스트
- [✅ ] 로컬에서 빌드 및 테스트 완료
- [✅ ] 관련 문서/주석 보강
