### PR TITLE
feat: add admin notice list API

### DIFF
--- a/src/main/java/com/example/trx/apis/admin/AdminNoticeController.java
+++ b/src/main/java/com/example/trx/apis/admin/AdminNoticeController.java
@@ -1,0 +1,29 @@
+package com.example.trx.apis.admin;
+
+import com.example.trx.apis.dto.ApiResult;
+import com.example.trx.apis.notice.dto.NoticeSummaryResponse;
+import com.example.trx.service.notice.NoticeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/notices")
+@RequiredArgsConstructor
+@Tag(name = "Admin Notices", description = "관리자 공지 관리 API")
+public class AdminNoticeController {
+
+    private final NoticeService noticeService;
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "전체 공지 조회", description = "삭제되지 않은 모든 공지를 등록일 내림차순으로 조회합니다.")
+    public ApiResult<List<NoticeSummaryResponse>> getAllNotices() {
+        return ApiResult.succeed(noticeService.getAllNoticesForAdmin());
+    }
+}

--- a/src/main/java/com/example/trx/repository/notice/NoticeRepository.java
+++ b/src/main/java/com/example/trx/repository/notice/NoticeRepository.java
@@ -15,4 +15,6 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     Page<Notice> findByPinnedIsFalseAndApplyAtLessThanEqualAndDeletedFalse(LocalDateTime applyAt, Pageable pageable);
 
     Optional<Notice> findByIdAndDeletedFalse(Long id);
+
+    List<Notice> findByDeletedFalse(Sort sort);
 }

--- a/src/main/java/com/example/trx/service/notice/NoticeService.java
+++ b/src/main/java/com/example/trx/service/notice/NoticeService.java
@@ -95,6 +95,15 @@ public class NoticeService {
         return toResponse(notice);
     }
 
+    @Transactional(readOnly = true)
+    public List<NoticeSummaryResponse> getAllNoticesForAdmin() {
+        Sort sort = Sort.by(Sort.Order.desc("createdAt"));
+        return noticeRepository.findByDeletedFalse(sort)
+            .stream()
+            .map(this::toSummary)
+            .collect(Collectors.toList());
+    }
+
     @Transactional
     public NoticeResponse updateNotice(Long noticeId, NoticeUpdateRequest request) {
         Notice notice = noticeRepository.findByIdAndDeletedFalse(noticeId)


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #49 

## ✨ 변경 내용
- 관리자 전용 공지 목록 API (GET /api/v1/admin/notices)를 추가했습니다.
- 삭제되지 않은 모든 공지를 createdAt 내림차순으로 반환하며, ROLE_ADMIN 권한이 있어야 접근
  할 수 있습니다.
- 이를 위해 NoticeService와 NoticeRepository에 전체 공지를 가져올 수 있는 메서드를 추가했습
  니다.

## ✅ 체크리스트
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 관련 문서/주석 보강
