### PR TITLE
fix: 라운드 초기화가 순서대로 되지 않던 문제를 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ build/
 !**/src/test/**/build/
 
 
+### data ###
+/src/main/resources/data.xlsx
+
 
 ### VS Code ###
 .vscode/

--- a/src/main/java/com/example/trx/domain/event/round/Round.java
+++ b/src/main/java/com/example/trx/domain/event/round/Round.java
@@ -72,7 +72,10 @@ public class Round {
   private List<Match> matches =  new ArrayList<>();
 
   public void addParticipants(List<Participant> participants) {
-    if (participants.size() > participantLimit) throw new IllegalArgumentException("참가자 제한 수 초과");
+    if (participants.size() > participantLimit) {
+      log.info("participants.size(): {}, limit: {}", participants.size(), participantLimit);
+      throw new IllegalArgumentException("참가자 제한 수 초과");
+    }
     RoundProgressionType progressionType = contestEvent.getProgressionType();
 
     switch (progressionType) {

--- a/src/main/java/com/example/trx/service/event/ContestEventInitializer.java
+++ b/src/main/java/com/example/trx/service/event/ContestEventInitializer.java
@@ -7,12 +7,14 @@ import com.example.trx.domain.event.RoundProgressionType;
 import com.example.trx.domain.event.exception.ContestEventNotFound;
 import com.example.trx.repository.event.ContestEventRepository;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,23 +49,23 @@ public class ContestEventInitializer implements ApplicationRunner {
   }
 
   private void initFreeStyleRounds() {
-      Map<String, Integer> beginner = Map.copyOf(new LinkedHashMap<>() {{
-        put("qualifier", 10);
-        put("semifinal", 5);
-        put("final", 3);
-      }});
+      List<Map.Entry<String, Integer>> beginner = List.of (
+        Map.entry("qualifier", 10),
+        Map.entry("semifinal", 5),
+        Map.entry("final", 3)
+      );
 
-      Map<String, Integer> open = Map.copyOf(new LinkedHashMap<>() {{
-        put("qualifier", 13);
-        put("semifinal", 7);
-        put("final", 4);
-      }});
+      List<Map.Entry<String, Integer>> open= List.of(
+        Map.entry("qualifier", 13),
+        Map.entry("semifinal", 7),
+        Map.entry("final", 4)
+      );
 
-      Map<String, Integer> pro = Map.copyOf(new LinkedHashMap<>() {{
-        put("qualifier", 21);
-        put("semifinal", 11);
-        put("final", 4);
-      }});
+    List<Map.Entry<String, Integer>> pro= List.of(
+        Map.entry("qualifier", 21),
+        Map.entry("semifinal", 11),
+        Map.entry("final", 4)
+      );
 
     for (Division division : Division.values()) {
       ContestEvent cev = contestEventRepository.findContestEventByDivisionAndDisciplineCode(division, DisciplineCode.FREESTYLE)
@@ -78,24 +80,24 @@ public class ContestEventInitializer implements ApplicationRunner {
   }
 
   private void initSlalomRounds() {
-    Map<String, Integer> beginner = Map.copyOf(new LinkedHashMap<>() {{
-      put("round16", 16);
-      put("round8", 8);
-      put("semifinal", 4);
-      put("final", 2);
-    }});
+    List<Map.Entry<String, Integer>> beginner = List.of(
+      Map.entry("round16", 16),
+      Map.entry("round8", 8),
+      Map.entry("semifinal", 4),
+      Map.entry("final", 2)
+    );
 
-    Map<String, Integer> open = Map.copyOf(new LinkedHashMap<>() {{
-      put("round8", 8);
-      put("semifinal", 4);
-      put("final", 2);
-    }});
+    List<Map.Entry<String, Integer>> open = List.of(
+      Map.entry("round8", 8),
+      Map.entry("semifinal", 4),
+      Map.entry("final", 2)
+    );
 
-    Map<String, Integer> pro = Map.copyOf(new LinkedHashMap<>() {{
-      put("round8", 8);
-      put("semifinal", 4);
-      put("final", 2);
-    }});
+    List<Map.Entry<String, Integer>> pro = List.of(
+      Map.entry("round8", 8),
+      Map.entry("semifinal", 4),
+      Map.entry("final", 2)
+    );
 
     for (Division division : Division.values()) {
       ContestEvent cev = contestEventRepository.findContestEventByDivisionAndDisciplineCode(division, DisciplineCode.SLALOM)
@@ -112,17 +114,17 @@ public class ContestEventInitializer implements ApplicationRunner {
   }
 
   private void initDancingRounds() {
-    Map<String, Integer> beginner = Map.copyOf(new LinkedHashMap<>() {{
-      put("final", 5);
-    }});
+    List<Map.Entry<String, Integer>> beginner = List.of(
+      Map.entry("final", 5)
+    );
 
-    Map<String, Integer> open = Map.copyOf(new LinkedHashMap<>() {{
-      put("final", 7);
-    }});
+    List<Map.Entry<String, Integer>> open = List.of(
+      Map.entry("final", 7)
+    );
 
-    Map<String, Integer> pro = Map.copyOf(new LinkedHashMap<>() {{
-      put("final", 12);
-    }});
+    List<Map.Entry<String, Integer>> pro = List.of(
+      Map.entry("final", 12)
+    );
 
     for (Division division : Division.values()) {
       ContestEvent cev = contestEventRepository.findContestEventByDivisionAndDisciplineCode(division, DisciplineCode.LONGBOARD_DANCING)
@@ -136,7 +138,11 @@ public class ContestEventInitializer implements ApplicationRunner {
     }
   }
 
-  private void addRounds(ContestEvent contestEvent, Map<String, Integer> rounds, Integer runPerParticipant) {
-    rounds.forEach((name, limit) -> domainService.addRound(contestEvent.getId(), name, limit, runPerParticipant));
+  private void addRounds(ContestEvent contestEvent, List<Map.Entry<String, Integer>> rounds, Integer runPerParticipant) {
+    rounds.forEach(round -> {
+      String name = round.getKey();
+      Integer limit = round.getValue();
+      domainService.addRound(contestEvent.getId(), name, limit, runPerParticipant);
+    });
   }
 }

--- a/src/main/java/com/example/trx/service/user/ParticipantService.java
+++ b/src/main/java/com/example/trx/service/user/ParticipantService.java
@@ -39,11 +39,16 @@ public class ParticipantService {
       private final ParticipantRepository participantRepository;
       private final ContestEventRepository contestEventRepository;
 
-        @Transactional
+      @Transactional
       public int readExcel() throws IOException {
           int count = 0;
+
+          ClassPathResource resource = new ClassPathResource("data.xlsx");
+
+          File file =  resource.getFile();
+
           String filePath = "C:\\Users\\mycoo\\Documents\\카카오톡 받은 파일\\data.xlsx";
-          try (FileInputStream fis = new FileInputStream(filePath);
+          try (FileInputStream fis = new FileInputStream(file);
                Workbook workbook = new XSSFWorkbook(fis)) {
 
               SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd"); // 원하는 날짜 포맷 지정

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,7 +27,7 @@ spring:
       path: /h2-console
   datasource:
     #### h2 설정
-    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL
+    url: jdbc:h2:file:~/testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa
     password:
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
## ✨ 변경 내용
- 종목별 라운드 초기화 시 주어진 순서대로 초기화가 이루어지지 않아 대회 시작 및 라운드 진행이 제대로 되지 않던 문제를 수정했습니다
- 테스트를 위해 ParticipantService에 임시로 src/main/resources/에 data.xlsx를 두고 초기화하도록 수정했습니다
  - application.yml에 h2를 메모리 -> 파일로 변경 (ddl-auto: create -> update로 수정 필요) 
  - .gitignore에 /src/main/resources/data.xlsx를 추가