### PR TITLE
feat: 공지 수정 시 더이상 예약 정보를 참조하지 않음

### DIFF
--- a/src/main/java/com/example/trx/service/notice/NoticeService.java
+++ b/src/main/java/com/example/trx/service/notice/NoticeService.java
@@ -109,15 +109,6 @@ public class NoticeService {
         Notice notice = noticeRepository.findByIdAndDeletedFalse(noticeId)
             .orElseThrow(() -> new NoticeNotFoundException(noticeId));
 
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime applyAt = request.getApplyAt() != null
-            ? request.getApplyAt()
-            : notice.getApplyAt();
-
-        if (applyAt.isBefore(now)) {
-            throw new InvalidNoticeScheduleException("적용 시각은 현재 시각보다 과거일 수 없습니다.");
-        }
-
         NoticeImportance importance = request.getImportance() != null
             ? request.getImportance()
             : notice.getImportance();
@@ -126,7 +117,6 @@ public class NoticeService {
         notice.setContent(request.getContent());
         notice.setPinned(request.isPinned());
         notice.setImportance(importance);
-        notice.setApplyAt(applyAt);
 
         return toResponse(notice);
     }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #73 

## ✨ 변경 내용
- 공지 수정 시 예약 시간을 참조하지 않게 변경

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 관련 문서/주석 보강
