### PR TITLE
fix: 심사위원 로그인 시 심사위원 id를 같이 넣어서 보내도록 변경

### DIFF
--- a/src/main/java/com/example/trx/apis/admin/dto/AdminTokenResponse.java
+++ b/src/main/java/com/example/trx/apis/admin/dto/AdminTokenResponse.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 public class AdminTokenResponse {
     private final TokenType tokenType;
     private final String token;
+    private final Long judgeId;
 
     public enum TokenType {
         BEARER

--- a/src/main/java/com/example/trx/service/judge/JudgeService.java
+++ b/src/main/java/com/example/trx/service/judge/JudgeService.java
@@ -110,6 +110,7 @@ public class JudgeService {
         return AdminTokenResponse.builder()
             .token(token)
             .tokenType(AdminTokenResponse.TokenType.BEARER)
+            .judgeId(judge.getId())
             .build();
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #80 

## ✨ 변경 내용
- 심사위원 로그인 응답 dto에 judgeId 필드 추가

## ✅ 체크리스트
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 관련 문서/주석 보강
